### PR TITLE
Fix C and CXX flags so user flags are respected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,8 @@ IF(BUILD_GUI)
 	link_directories   ( ${X11_LIBRARY_DIRS} )
 ENDIF(BUILD_GUI)
 
-SET(CMAKE_C_FLAGS "-fPIC" ${CFLAGS}  )
-SET(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete  -Wl,--no-undefined -fPIC -shared ")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete -Wl,--no-undefined -fPIC -shared")
 
 # for profiling runtime
 #ADD_DEFINITIONS( "-DOPENAV_PROFILE" )
@@ -69,10 +69,9 @@ SET(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function 
 ### Build Tests OR lv2
 ######################
 IF( FABLA2_TESTS )
-  
+
   ADD_DEFINITIONS( "-DFABLA2_COMPONENT_TEST" )
-  
-  SET(CMAKE_CXX_FLAGS "-g -trigraphs -Wl,-z,nodelete  -Wl,--no-undefined") # -fsanitize=address
+  # SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
   FILE(GLOB srcDspTests src/dsp/tests/*.cxx src/dsp/*.cxx )
   ADD_EXECUTABLE( fabla2test ${srcDspTests} )
   target_link_libraries( fabla2test ${SNDFILE_LIBRARIES})
@@ -81,8 +80,6 @@ IF( FABLA2_TESTS )
 
 ELSE()
 
-  SET(CMAKE_C_FLAGS "-fPIC" ${CFLAGS}  )
-  
   FILE(GLOB srcDSP src/dsp.cxx src/lv2_work.cxx src/lv2_state.cxx src/dsp/*.cxx src/dsp/*.c )
   FILE(GLOB srcUI  src/ui.cxx src/ui/sofd/libsofd.c src/ui/*.cxx src/ui/avtk/avtk/*.cxx src/ui/avtk/avtk/pugl/pugl_x11.c )
   


### PR DESCRIPTION
This makes sure that user C and CXX flags are honoured

Sample output before change:
```
Compiler flags:
C               -fPIC
C++             -Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete  -Wl,--no-undefined -fPIC -shared 
Linker flags:
Executable      -Wl,-O1 -Wl,--as-needed
Module          -Wl,-O1 -Wl,--as-needed
Shared          -Wl,-O1 -Wl,--as-needed
```
```
/usr/bin/x86_64-pc-linux-gnu-g++  -DAVTK_SNDFILE -DFABLA2_VERSION_STRING="\"v 2.0.0\"" -DHAVE_X11 -DPUGL_HAVE_CAIRO -Dfabla2_EXPORTS -I/var/tmp/portage/media-plugins/fabla2-9999/work/fabla2-9999/src/ui/avtk/avtk -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16   -DNDEBUG -Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete  -Wl,--no-undefined -fPIC -shared  -fPIC   -o CMakeFiles/fabla2.dir/src/dsp.cxx.o -c /var/tmp/portage/media-plugins/fabla2-9999/work/fabla2-9999/src/dsp.cxx
```

And after the change
```
C               -march=core-avx-i -O2 -pipe -fPIC
C++             -march=core-avx-i -O2 -pipe -Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete -Wl,--no-undefined -fPIC -shared
Linker flags:
Executable      -Wl,-O1 -Wl,--as-needed
Module          -Wl,-O1 -Wl,--as-needed
Shared          -Wl,-O1 -Wl,--as-needed
```
```
/usr/bin/x86_64-pc-linux-gnu-g++  -DAVTK_SNDFILE -DFABLA2_VERSION_STRING="\"v 2.0.0\"" -DHAVE_X11 -DPUGL_HAVE_CAIRO -Dfabla2_EXPORTS -I/var/tmp/portage/media-plugins/fabla2-9999/work/fabla2-9999/src/ui/avtk/avtk -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16   -DNDEBUG -march=core-avx-i -O2 -pipe -Wall -Wno-sign-compare -g -trigraphs -Wno-unused-function -Wno-unused-variable -Wno-reorder -Wuninitialized -Wl,-z,nodelete -Wl,--no-undefined -fPIC -shared -fPIC   -o CMakeFiles/fabla2.dir/src/dsp.cxx.o -c /var/tmp/portage/media-plugins/fabla2-9999/work/fabla2-9999/src/dsp.cxx
```